### PR TITLE
Fix broken link in Homebrew PHP post

### DIFF
--- a/content/post/homebrew-migrate-your-php-setup.md
+++ b/content/post/homebrew-migrate-your-php-setup.md
@@ -59,7 +59,7 @@ below.
 ## 5. Install Extensions
 
 The `intl` is now already built in.
-Install all other required extensions via [PECL] (gets installed together with PHP).
+Install all other required extensions via [PECL][] (gets installed together with PHP).
 
 Installation via pecl requires autoconf (`brew install autoconf`):
 


### PR DESCRIPTION
The parentheses were interpreted as the link href. Adding a `[]` tells Markdown the href will be specified later.